### PR TITLE
Make Swiboe work over TCP connections

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -19,7 +19,7 @@ use test::Bencher;
 #[bench]
 fn bench_create_and_delete_buffers(b: &mut Bencher) {
     let t = TestHarness::new();
-    let active_client = Client::connect(&t.socket_name).unwrap();
+    let active_client = Client::connect_unix(&t.socket_name).unwrap();
 
     b.iter(|| {
         let new_response: plugin_buffer::NewResponse = match active_client.call(

--- a/gtk_gui/src/bin/gtk_gui.rs
+++ b/gtk_gui/src/bin/gtk_gui.rs
@@ -191,7 +191,7 @@ impl SwiboeGtkGui {
 fn main() {
     gtk::init().unwrap_or_else(|_| panic!("Failed to initialize GTK."));
 
-    let client = client::Client::connect(path::Path::new("/tmp/sb.socket").connect());
+    let client = client::Client::connect_unix(path::Path::new("/tmp/sb.socket").connect());
     let mut swiboe = SwiboeGtkGui::new(&client);
 
     let join_handle = thread::spawn(move || {

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -25,7 +25,7 @@ fn main() {
         .get_matches();
 
     let path = path::Path::new(matches.value_of("SOCKET").unwrap());
-    let active_client = Client::connect(path).unwrap();
+    let active_client = Client::connect_unix(path).unwrap();
 
     loop {
         let new_response: plugin_buffer::NewResponse = match active_client.call(

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -19,6 +19,7 @@ fn main() {
         .get_matches();
 
     let path = Path::new(matches.value_of("SOCKET").unwrap());
-    let mut server = swiboe::server::Server::launch(path);
+    // NOCOM(#sirver): just for testing
+    let mut server = swiboe::server::Server::launch(path, &vec!["0.0.0.0:55555"]);
     server.wait_for_shutdown();
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -16,10 +16,21 @@ fn main() {
              .help("Socket address on which to listen.")
              .required(true)
              .takes_value(true))
+        .arg(clap::Arg::with_name("LISTEN")
+             .short("l")
+             .long("listen")
+             .help("IP address to listen on, e.g. 0.0.0.0:12345 to listen on all network \
+                   interfaces.")
+             .takes_value(true))
         .get_matches();
 
     let path = Path::new(matches.value_of("SOCKET").unwrap());
-    // NOCOM(#sirver): just for testing
-    let mut server = swiboe::server::Server::launch(path, &vec!["0.0.0.0:55555"]);
+    let ips = if let Some(addr) = matches.value_of("LISTEN") {
+        vec![addr.into()]
+    } else {
+        Vec::new()
+    };
+
+    let mut server = swiboe::server::Server::launch(path, &ips);
     server.wait_for_shutdown();
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -32,7 +32,7 @@ impl Client {
         Ok(Client::common_connect(stream))
     }
 
-    fn common_connect<T: event_loop::SizedMioStream + 'static>(stream: T) -> Self {
+    fn common_connect<T: event_loop::TryClone + 'static>(stream: T) -> Self {
         let (commands_tx, commands_rx) = mpsc::channel();
         let (event_loop_thread, event_loop_commands) = event_loop::spawn(stream, commands_tx.clone());
         Client {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,10 +2,13 @@
 
 use ::error::Result;
 use ::plugin_core::NewRpcRequest;
+use mio::tcp::TcpStream;
 use mio::unix::UnixStream;
 use mio;
 use serde;
+use std::net;
 use std::path;
+use std::str::FromStr;
 use std::sync::Mutex;
 use std::sync::mpsc;
 use std::thread;
@@ -19,18 +22,25 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn connect(socket_name: &path::Path) -> Result<Self> {
+    pub fn connect_unix(socket_name: &path::Path) -> Result<Self> {
         let stream = try!(UnixStream::connect(&socket_name));
+        Ok(Client::common_connect(stream))
+    }
 
+    pub fn connect_tcp(address: &net::SocketAddr) -> Result<Self> {
+        let stream = try!(TcpStream::connect(address));
+        Ok(Client::common_connect(stream))
+    }
+
+    fn common_connect<T: event_loop::SizedMioStream + 'static>(stream: T) -> Self {
         let (commands_tx, commands_rx) = mpsc::channel();
         let (event_loop_thread, event_loop_commands) = event_loop::spawn(stream, commands_tx.clone());
-
-        Ok(Client {
+        Client {
             event_loop_commands: event_loop_commands.clone(),
             rpc_loop_commands: commands_tx.clone(),
             rpc_loop_thread: Some(rpc_loop::spawn(commands_rx, commands_tx, event_loop_commands)),
             event_loop_thread: Some(event_loop_thread),
-        })
+        }
     }
 
     pub fn new_rpc(&self, name: &str, rpc: Box<rpc::server::Rpc>) {

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -17,7 +17,7 @@ pub enum Message {
 // TODO(hrapp): This kinda defeats the purpose of MIO a bit, but it makes it very convenient to
 // read always a full message. No buffering of our own is needed then. This might impact
 // performance really negatively and might also lead to deadlooks, so we should get rid of it AFAP.
-// mio provides some buffers that look usefull.
+// mio provides some buffers that look useful.
 fn write_all<T: Write>(writer: &mut T, buffer: &[u8]) -> io::Result<()> {
     let mut num_written = 0;
     while num_written < buffer.len() {

--- a/src/ipc_bridge.rs
+++ b/src/ipc_bridge.rs
@@ -19,7 +19,10 @@ pub struct ClientId {
     pub token: mio::Token,
 }
 
-trait MioStream: io::Read + io::Write + Send + mio::Evented {
+// We abstract over unix and TCP connections. Since receiver and sender both get a copy of the
+// socket, we need to clone them. Since we store them in slab (which means the trait cannot be
+// sized), we have to return boxes too.
+trait MioStream: Send + io::Read + io::Write + mio::Evented {
     fn try_clone(&self) -> io::Result<Box<MioStream>>;
 }
 

--- a/src/plugin_buffer.rs
+++ b/src/plugin_buffer.rs
@@ -301,7 +301,7 @@ pub struct BufferPlugin {
 
 impl BufferPlugin {
     pub fn new(socket_name: &path::Path) -> Self {
-        let client = client::Client::connect(socket_name).unwrap();
+        let client = client::Client::connect_unix(socket_name).unwrap();
 
         let plugin = BufferPlugin {
             buffers: Arc::new(RwLock::new(BuffersManager::new(client.clone()))),

--- a/src/plugin_list_files.rs
+++ b/src/plugin_list_files.rs
@@ -95,7 +95,7 @@ pub struct ListFilesPlugin {
 
 impl ListFilesPlugin {
     pub fn new(socket_name: &path::Path) -> Self {
-        let client = client::Client::connect(socket_name).unwrap();
+        let client = client::Client::connect_unix(socket_name).unwrap();
 
         let plugin = ListFilesPlugin {
             client: client,

--- a/term_gui/Cargo.lock
+++ b/term_gui/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "mio"
 version = "0.5.0-pre"
-source = "git+https://github.com/carllerche/mio.git?rev=3537a6980ae718d40f53e422f7a88ec7bc50299e#3537a6980ae718d40f53e422f7a88ec7bc50299e"
+source = "git+https://github.com/carllerche/mio.git?rev=29ee9841c6dc051d4ead4f9cb9618c0fac732155#29ee9841c6dc051d4ead4f9cb9618c0fac732155"
 dependencies = [
  "bytes 0.2.10 (git+https://github.com/carllerche/bytes?rev=7edb577d0a)",
  "clock_ticks 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -266,7 +266,7 @@ version = "0.1.0"
 dependencies = [
  "clap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.5.0-pre (git+https://github.com/carllerche/mio.git?rev=3537a6980ae718d40f53e422f7a88ec7bc50299e)",
+ "mio 0.5.0-pre (git+https://github.com/carllerche/mio.git?rev=29ee9841c6dc051d4ead4f9cb9618c0fac732155)",
  "serde 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_macros 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/term_gui/src/bin/term_gui.rs
+++ b/term_gui/src/bin/term_gui.rs
@@ -46,8 +46,7 @@ impl CompleterWidget {
         // TODO(sirver): This should use the current work directory of the server, since the server
         // might run on a different machine than the client - and certainly in a different
         // directory.
-        // let current_dir = env::current_dir().unwrap();
-        let current_dir = path::PathBuf::from("/home/sirver/code");
+        let current_dir = env::current_dir().unwrap();
 
         let rpc = client.call("list_files", &swiboe::plugin_list_files::ListFilesRequest {
             directory: current_dir.to_string_lossy().into_owned(),
@@ -224,14 +223,11 @@ struct TerminalGui {
 
 impl TerminalGui {
     fn new(options: &Options) -> Self {
-        println!("#sirver options: {:#?}", options);
         let client = match net::SocketAddr::from_str(&options.socket) {
             Ok(value) => {
-                println!("#sirver value: {:#?}", value);
                 client::Client::connect_tcp(&value).unwrap()
             }
             Err(e) => {
-                println!("#sirver e: {:#?}", e);
                 let socket_path = path::PathBuf::from(&options.socket);
                 client::Client::connect_unix(&socket_path).unwrap()
             }

--- a/term_gui/src/bin/term_gui.rs
+++ b/term_gui/src/bin/term_gui.rs
@@ -13,7 +13,9 @@ use gui::keymap_handler;
 use rustbox::{Color, RustBox};
 use std::cmp;
 use std::env;
+use std::net;
 use std::path;
+use std::str::FromStr;
 use std::sync::mpsc;
 use std::sync::{RwLock, Arc, Mutex};
 use swiboe::client;
@@ -199,8 +201,9 @@ impl BufferViewWidget {
     }
 }
 
+#[derive(Debug)]
 struct Options {
-    socket: path::PathBuf,
+    socket: String,
     config_file: path::PathBuf,
 }
 
@@ -220,7 +223,19 @@ struct TerminalGui {
 
 impl TerminalGui {
     fn new(options: &Options) -> Self {
-        let client = client::Client::connect(&options.socket).unwrap();
+        println!("#sirver options: {:#?}", options);
+        let client = match net::SocketAddr::from_str(&options.socket) {
+            Ok(value) => {
+                println!("#sirver value: {:#?}", value);
+                client::Client::connect_tcp(&value).unwrap()
+            }
+            Err(e) => {
+                println!("#sirver e: {:#?}", e);
+                let socket_path = path::PathBuf::from(&options.socket);
+                client::Client::connect_unix(&socket_path).unwrap()
+            }
+        };
+
 
         let mut config_file_runner = gui::config_file::ConfigFileRunner::new(
             client.clone());
@@ -376,10 +391,9 @@ fn parse_options() -> Options {
              .takes_value(true))
         .get_matches();
 
-
     Options {
         config_file: path::PathBuf::from(matches.value_of("CONFIG_FILE").unwrap_or("config.lua")),
-        socket: path::PathBuf::from(matches.value_of("SOCKET").unwrap()),
+        socket: matches.value_of("SOCKET").unwrap().into(),
     }
 }
 

--- a/term_gui/src/bin/term_gui.rs
+++ b/term_gui/src/bin/term_gui.rs
@@ -46,7 +46,8 @@ impl CompleterWidget {
         // TODO(sirver): This should use the current work directory of the server, since the server
         // might run on a different machine than the client - and certainly in a different
         // directory.
-        let current_dir = env::current_dir().unwrap();
+        // let current_dir = env::current_dir().unwrap();
+        let current_dir = path::PathBuf::from("/home/sirver/code");
 
         let rpc = client.call("list_files", &swiboe::plugin_list_files::ListFilesRequest {
             directory: current_dir.to_string_lossy().into_owned(),

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -23,7 +23,7 @@ fn as_json(s: &str) -> serde_json::Value {
 #[test]
 fn shutdown_server_with_clients_connected() {
     let socket_name = temporary_socket_name();
-    let mut server = Server::launch(&socket_name);
+    let mut server = Server::launch(&socket_name, &[]);
 
     let _client = client::Client::connect(&socket_name).unwrap();
 

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -25,7 +25,7 @@ fn shutdown_server_with_clients_connected() {
     let socket_name = temporary_socket_name();
     let mut server = Server::launch(&socket_name, &[]);
 
-    let _client = client::Client::connect(&socket_name).unwrap();
+    let _client = client::Client::connect_unix(&socket_name).unwrap();
 
     server.shutdown();
 }
@@ -33,7 +33,7 @@ fn shutdown_server_with_clients_connected() {
 #[test]
 fn shutdown_server_with_no_clients_connected() {
     let t = TestHarness::new();
-    let _client = client::Client::connect(&t.socket_name).unwrap();
+    let _client = client::Client::connect_unix(&t.socket_name).unwrap();
 }
 
 struct TestCall {
@@ -53,8 +53,8 @@ impl client::rpc::server::Rpc for TestCall {
 fn new_rpc_simple() {
     let t = TestHarness::new();
 
-    let client1 = client::Client::connect(&t.socket_name).unwrap();
-    let client2 = client::Client::connect(&t.socket_name).unwrap();
+    let client1 = client::Client::connect_unix(&t.socket_name).unwrap();
+    let client2 = client::Client::connect_unix(&t.socket_name).unwrap();
 
     let test_msg: serde_json::Value = as_json(r#"{ "blub": "blah" }"#);
 
@@ -71,20 +71,20 @@ fn new_rpc_simple() {
 fn new_rpc_with_priority() {
     let t = TestHarness::new();
 
-    let client1 = client::Client::connect(&t.socket_name).unwrap();
+    let client1 = client::Client::connect_unix(&t.socket_name).unwrap();
     client1.new_rpc("test.test", Box::new(TestCall {
         priority: 100,
         result: rpc::Result::Ok(as_json(r#"{ "from": "client1" }"#)),
     }));
 
 
-    let client2 = client::Client::connect(&t.socket_name).unwrap();
+    let client2 = client::Client::connect_unix(&t.socket_name).unwrap();
     client2.new_rpc("test.test", Box::new(TestCall {
         priority: 50,
         result: rpc::Result::Ok(as_json(r#"{ "from": "client2" }"#)),
     }));
 
-    let client3 = client::Client::connect(&t.socket_name).unwrap();
+    let client3 = client::Client::connect_unix(&t.socket_name).unwrap();
     let mut rpc = client3.call("test.test", &as_json(r#"{}"#));
     assert_eq!(rpc::Result::Ok(as_json(r#"{ "from": "client2" }"#)), rpc.wait().unwrap());
 }
@@ -93,20 +93,20 @@ fn new_rpc_with_priority() {
 fn new_rpc_with_priority_first_does_not_handle() {
     let t = TestHarness::new();
 
-    let client1 = client::Client::connect(&t.socket_name).unwrap();
+    let client1 = client::Client::connect_unix(&t.socket_name).unwrap();
     client1.new_rpc("test.test", Box::new(TestCall {
         priority: 100,
         result: rpc::Result::Ok(as_json(r#"{ "from": "client1" }"#)),
     }));
 
 
-    let client2 = client::Client::connect(&t.socket_name).unwrap();
+    let client2 = client::Client::connect_unix(&t.socket_name).unwrap();
     client2.new_rpc("test.test", Box::new(TestCall {
         priority: 50,
         result: rpc::Result::NotHandled,
     }));
 
-    let client3 = client::Client::connect(&t.socket_name).unwrap();
+    let client3 = client::Client::connect_unix(&t.socket_name).unwrap();
     let mut rpc = client3.call("test.test", &as_json(r#"{}"#));
     assert_eq!(rpc::Result::Ok(as_json(r#"{ "from": "client1" }"#)), rpc.wait().unwrap());
 }
@@ -115,29 +115,29 @@ fn new_rpc_with_priority_first_does_not_handle() {
 fn client_disconnects_should_not_stop_handling_of_rpcs() {
     let t = TestHarness::new();
 
-    let client0 = client::Client::connect(&t.socket_name).unwrap();
+    let client0 = client::Client::connect_unix(&t.socket_name).unwrap();
     client0.new_rpc("test.test", Box::new(TestCall {
             priority: 100, result: rpc::Result::NotHandled,
     }));
 
-    let client1 = client::Client::connect(&t.socket_name).unwrap();
+    let client1 = client::Client::connect_unix(&t.socket_name).unwrap();
     client1.new_rpc("test.test", Box::new(TestCall {
             priority: 101, result:
                 rpc::Result::Ok(as_json(r#"{ "from": "client1" }"#)),
     }));
 
-    let client2 = client::Client::connect(&t.socket_name).unwrap();
+    let client2 = client::Client::connect_unix(&t.socket_name).unwrap();
     client2.new_rpc("test.test", Box::new(TestCall {
             priority: 102, result: rpc::Result::NotHandled,
     }));
 
-    let client3 = client::Client::connect(&t.socket_name).unwrap();
+    let client3 = client::Client::connect_unix(&t.socket_name).unwrap();
     client3.new_rpc("test.test", Box::new(TestCall {
             priority: 103, result:
                 rpc::Result::Ok(as_json(r#"{ "from": "client3" }"#)),
     }));
 
-    let client = client::Client::connect(&t.socket_name).unwrap();
+    let client = client::Client::connect_unix(&t.socket_name).unwrap();
 
     let mut rpc = client.call("test.test", &as_json(r#"{}"#));
     assert_eq!(rpc::Result::Ok(as_json(r#"{ "from": "client1" }"#)), rpc.wait().unwrap());
@@ -167,7 +167,7 @@ fn client_disconnects_should_not_stop_handling_of_rpcs() {
 fn call_not_existing_rpc() {
     let t = TestHarness::new();
 
-    let client = client::Client::connect(&t.socket_name).unwrap();
+    let client = client::Client::connect_unix(&t.socket_name).unwrap();
     let mut rpc = client.call("not_existing", &as_json("{}"));
     assert_eq!(rpc::Result::Err(rpc::Error {
         kind: rpc::ErrorKind::UnknownRpc,
@@ -180,7 +180,7 @@ fn call_streaming_rpc_simple() {
     // NOCOM(#sirver): test for next_result on non streaming rpc
     let t = TestHarness::new();
 
-    let streaming_client = client::Client::connect(&t.socket_name).unwrap();
+    let streaming_client = client::Client::connect_unix(&t.socket_name).unwrap();
     streaming_client.new_rpc("test.test", Box::new(CallbackRpc {
         priority: 50,
         callback: |mut context: client::rpc::server::Context, _| {
@@ -193,7 +193,7 @@ fn call_streaming_rpc_simple() {
         },
     }));
 
-    let client = client::Client::connect(&t.socket_name).unwrap();
+    let client = client::Client::connect_unix(&t.socket_name).unwrap();
     let mut rpc = client.call("test.test", &as_json("{}"));
 
     assert_eq!(as_json(r#"{ "msg": "one" }"#), rpc.recv().unwrap().unwrap());
@@ -207,7 +207,7 @@ fn call_streaming_rpc_cancelled() {
     let cancelled = sync::Arc::new(sync::Mutex::new(false));
 
     let t = TestHarness::new();
-    let streaming_client = client::Client::connect(&t.socket_name).unwrap();
+    let streaming_client = client::Client::connect_unix(&t.socket_name).unwrap();
     let cancelled_clone = cancelled.clone();
     streaming_client.new_rpc("test.test", Box::new(CallbackRpc {
         priority: 50,
@@ -230,7 +230,7 @@ fn call_streaming_rpc_cancelled() {
         },
     }));
 
-    let client = client::Client::connect(&t.socket_name).unwrap();
+    let client = client::Client::connect_unix(&t.socket_name).unwrap();
     let mut rpc = client.call("test.test", &as_json("{}"));
 
     assert_eq!(as_json(r#"{ "value": "0" }"#), rpc.recv().unwrap().unwrap());

--- a/tests/plugin_buffer.rs
+++ b/tests/plugin_buffer.rs
@@ -20,7 +20,7 @@ fn buffer_new() {
     let t = TestHarness::new();
     let callback_called = Arc::new(Mutex::new(false));
     {
-        let client = client::Client::connect(&t.socket_name).unwrap();
+        let client = client::Client::connect_unix(&t.socket_name).unwrap();
         let callback_called = callback_called.clone();
         client.new_rpc("on.buffer.new", Box::new(CallbackRpc {
             priority: 100,
@@ -37,7 +37,7 @@ fn buffer_new() {
 #[test]
 fn buffer_new_with_content() {
     let t = TestHarness::new();
-    let client = client::Client::connect(&t.socket_name).unwrap();
+    let client = client::Client::connect_unix(&t.socket_name).unwrap();
 
     let content = "blub\nblah\nbli";
     create_buffer(&client, 0, Some(content));
@@ -53,7 +53,7 @@ fn buffer_new_with_content() {
 #[test]
 fn buffer_open_unhandled_uri() {
     let t = TestHarness::new();
-    let client = client::Client::connect(&t.socket_name).unwrap();
+    let client = client::Client::connect_unix(&t.socket_name).unwrap();
 
     let mut rpc = client.call("buffer.open", &plugin_buffer::OpenRequest {
         uri: "blumba://foo".into(),
@@ -65,7 +65,7 @@ fn buffer_open_unhandled_uri() {
 #[test]
 fn buffer_open_file() {
     let t = TestHarness::new();
-    let client = client::Client::connect(&t.socket_name).unwrap();
+    let client = client::Client::connect_unix(&t.socket_name).unwrap();
 
     let content = "blub\nblah\nbli";
     let path = create_file(&t, "foo", &content);
@@ -90,7 +90,7 @@ fn buffer_delete() {
     let t = TestHarness::new();
     let callback_called = Arc::new(Mutex::new(false));
     {
-        let client = client::Client::connect(&t.socket_name).unwrap();
+        let client = client::Client::connect_unix(&t.socket_name).unwrap();
         let callback_called = callback_called.clone();
         client.new_rpc("on.buffer.deleted", Box::new(CallbackRpc {
             priority: 100,
@@ -115,7 +115,7 @@ fn buffer_delete() {
 fn buffer_delete_non_existing() {
     let t = TestHarness::new();
 
-    let client = client::Client::connect(&t.socket_name).unwrap();
+    let client = client::Client::connect_unix(&t.socket_name).unwrap();
     let request = plugin_buffer::DeleteRequest {
         buffer_index: 0,
     };

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -15,7 +15,7 @@ impl TestHarness {
         let mut socket_name = temp_directory.path().to_path_buf();
         socket_name.push("_socket");
 
-        let server = Server::launch(&socket_name);
+        let server = Server::launch(&socket_name, &[]);
 
         TestHarness {
             server: Some(server),


### PR DESCRIPTION
So far it only worked over unix domain sockets. That is still required, since some plugins in the core expect to connect to it through this, but the server got a -l option that allows to also listen on TCP ports.