### PR TITLE
Update rust-lua53 to 099093a

### DIFF
--- a/gui/Cargo.toml
+++ b/gui/Cargo.toml
@@ -13,7 +13,7 @@ uuid = "0.1"
 
 [dependencies.lua]
 git = "https://github.com/jcmoyer/rust-lua53"
-rev = "2f3b6177f474db303db42340d4c4704724609437"
+rev = "099093a7008c78d7c87f616ea92bc89def8f4a48"
 
 [dependencies.swiboe]
 path = ".."


### PR DESCRIPTION
This bumps the revision of `rust-lua` to `099093a`, two commits behind master. They made &str/String changes recently, so further updating may need some more work.