### PR TITLE
Rename and cleanup

### DIFF
--- a/src/plugin/buffer.rs
+++ b/src/plugin/buffer.rs
@@ -300,14 +300,13 @@ impl ops::Deref for BuffersManager {
     }
 }
 
-pub struct BufferPlugin {
+pub struct Plugin {
     _client: client::Client,
     _buffers: Arc<RwLock<BuffersManager>>,
 }
 
-impl BufferPlugin {
-    pub fn new(socket_name: &path::Path) -> Result<Self> {
-        let mut client = try!(client::Client::connect_unix(socket_name));
+impl Plugin {
+    pub fn new(mut client: client::Client) -> Result<Self> {
         let buffers = Arc::new(RwLock::new(BuffersManager::new(try!(client.clone()))));
         let rpc_map = rpc_map! {
             "buffer.new" => New { buffers: buffers.clone() },
@@ -318,7 +317,7 @@ impl BufferPlugin {
         };
         try!(plugin::register_rpc(&mut client, rpc_map));
 
-        Ok(BufferPlugin{
+        Ok(Plugin{
             _client: client,
             _buffers: buffers,
         })

--- a/src/plugin/list_files.rs
+++ b/src/plugin/list_files.rs
@@ -13,7 +13,6 @@ use std::fs::{self, DirEntry};
 use std::io;
 use std::mem;
 use std::path::Path;
-use std::path;
 use std::sync::{Arc, RwLock};
 use std::thread;
 use time;
@@ -104,18 +103,17 @@ impl client::rpc::server::Rpc for ListFiles {
     }
 }
 
-pub struct ListFilesPlugin {
+pub struct Plugin {
     _client: client::Client,
 }
 
-impl ListFilesPlugin {
-    pub fn new(socket_name: &path::Path) -> Result<Self> {
-        let mut client = try!(client::Client::connect_unix(socket_name));
+impl Plugin {
+    pub fn new(mut client: client::Client) -> Result<Self> {
         let thin_client = Arc::new(RwLock::new(try!(client.clone())));
         try!(plugin::register_rpc(&mut client, rpc_map! {
             "list_files" => ListFiles { client: thin_client.clone() },
         }));
-        Ok(ListFilesPlugin {
+        Ok(Plugin {
             _client: client,
         })
     }

--- a/src/plugin/log/mod.rs
+++ b/src/plugin/log/mod.rs
@@ -4,7 +4,6 @@
 use ::client;
 use ::error::Result;
 use ::plugin;
-use std::path;
 use time;
 
 
@@ -13,8 +12,7 @@ pub struct Plugin {
 }
 
 impl Plugin {
-    pub fn new(socket_name: &path::Path) -> Result<Self> {
-        let mut client = try!(client::Client::connect_unix(socket_name));
+    pub fn new(mut client: client::Client) -> Result<Self> {
         try!(plugin::register_rpc(&mut client, rpc_map! {
             "log.debug" => debug::Rpc,
             "log.info" => info::Rpc,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE.txt
 // in the project root for license information.
 
+use ::client;
 use ::error::Result;
 use ::plugin;
 use mio;
@@ -21,8 +22,8 @@ pub struct Server {
     ipc_bridge_commands: mio::Sender<ipc_bridge::Command>,
     swiboe_thread: Option<thread::JoinHandle<()>>,
     event_loop_thread: Option<thread::JoinHandle<()>>,
-    buffer_plugin: Option<plugin::buffer::BufferPlugin>,
-    list_files_plugin: Option<plugin::list_files::ListFilesPlugin>,
+    buffer_plugin: Option<plugin::buffer::Plugin>,
+    list_files_plugin: Option<plugin::list_files::Plugin>,
     log_plugin: Option<plugin::log::Plugin>,
 }
 
@@ -54,12 +55,12 @@ impl Server {
             event_loop.run(&mut ipc_bridge).expect("Could not start event_loop.");
         }));
 
-        server.buffer_plugin = Some(
-            try!(plugin::buffer::BufferPlugin::new(&server.unix_domain_socket_name)));
-        server.list_files_plugin = Some(
-            try!(plugin::list_files::ListFilesPlugin::new(&server.unix_domain_socket_name)));
-        server.log_plugin = Some(
-            try!(plugin::log::Plugin::new(&server.unix_domain_socket_name)));
+        server.buffer_plugin = Some(try!(plugin::buffer::Plugin::new(
+                    try!(client::Client::connect_unix(&server.unix_domain_socket_name)))));
+        server.list_files_plugin = Some(try!(plugin::list_files::Plugin::new(
+                    try!(client::Client::connect_unix(&server.unix_domain_socket_name)))));
+        server.log_plugin = Some(try!(plugin::log::Plugin::new(
+                    try!(client::Client::connect_unix(&server.unix_domain_socket_name)))));
         Ok(server)
     }
 


### PR DESCRIPTION
1. Rename XXXPlugin to Plugin in modules.
2. Pass client to plugin constructor instead of path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/swiboe/swiboe/60)
<!-- Reviewable:end -->
